### PR TITLE
Reinstate call to gulp-concat in concat task.

### DIFF
--- a/gulp/tasks/concat.js
+++ b/gulp/tasks/concat.js
@@ -10,7 +10,7 @@ var destination = './leadpages-template/js';
 
 gulp.task('concat', 'Concatenate js files from `scripts` into vendor.js and functions.js', function () {
 
-	gulp.src(['./scripts/vendor/**/*.js'])
+	gulp.src(['./scripts/vendor/jquery-1.9.1.min.js','./scripts/vendor/**/*.js'])
 		.pipe(
 			logger({
 				before: 'Compiling vendor.js',
@@ -22,7 +22,10 @@ gulp.task('concat', 'Concatenate js files from `scripts` into vendor.js and func
 				showChange: true
 			})
 		)
-		.pipe(gulp.dest(destination));
+	        .pipe(concat('vendor.js'))
+	        	.on('error', handleErrors)
+	        .pipe(gulp.dest(destination)
+        );
 
 	gulp.src(['./scripts/scripts-header.js','./scripts/app/**/*.js','./scripts/scripts-footer.js'])
 		.pipe(
@@ -36,5 +39,8 @@ gulp.task('concat', 'Concatenate js files from `scripts` into vendor.js and func
 				showChange: true
 			})
 		)
-		.pipe(gulp.dest('./leadpages-template/js'));
+		.pipe(concat('functions.js'))
+    			.on('error', handleErrors)
+		.pipe(gulp.dest(destination)
+	);
 });


### PR DESCRIPTION
Unless I'm missing something since the version bump `gulp concat` wasn't concatenating js files but only copying them to the /leadpages-template/js directory. 

I've added the call to concat as well as individually defining the minified version of jQuery so that it is written to vendor.js before any other library.
